### PR TITLE
FEAT: Add SequenceMatcher algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,5 @@ exclude = ["/.github", "/dev"]
 categories = ["text-processing"]
 rust-version = "1.70.0"
 
-[features]
-default = [
-  "damerau_levenshtein", "gestalt", "hamming", "jaro",
-  "levenshtein", "optimal_string_alignment", "sorensen_dice"
-]
-damerau_levenshtein = []
-gestalt = []
-hamming = []
-jaro = []
-levenshtein = []
-optimal_string_alignment = []
-sorensen_dice = []
-
-
 [dev-dependencies]
 rstest = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,19 @@ exclude = ["/.github", "/dev"]
 categories = ["text-processing"]
 rust-version = "1.70.0"
 
+[features]
+default = [
+  "damerau_levenshtein", "gestalt", "hamming", "jaro",
+  "levenshtein", "optimal_string_alignment", "sorensen_dice"
+]
+damerau_levenshtein = []
+gestalt = []
+hamming = []
+jaro = []
+levenshtein = []
+optimal_string_alignment = []
+sorensen_dice = []
+
+
 [dev-dependencies]
 rstest = "0.18.2"

--- a/src/algorithms/gestalt.rs
+++ b/src/algorithms/gestalt.rs
@@ -1,0 +1,70 @@
+use crate::fuzzy::interface::{Similarity, SimilarityMetric};
+
+use std::collections::HashMap;
+
+/// Compares two strings `s1` and `s2` and returns a measure of their similarity as a float in the range [0, 1].
+///
+/// The returned measure is computed as follows:
+/// 1. If the total length of the two strings is 0, the function returns 1.0.
+/// 2. Otherwise, it computes the intersection of the character counts of the two strings,
+///    sums up the counts in the intersection, and returns the ratio of twice the sum of the counts to the total length.
+///
+/// # Arguments
+///
+/// * `s1` - The first string to compare.
+/// * `s2` - The second string to compare.
+///
+/// # Returns
+///
+/// * A float between 0 and 1 representing the similarity of the two strings.
+pub fn sequence_matcher(s1: &str, s2: &str) -> f64 {
+    let length = s1.len() + s2.len();
+
+    if length == 0 {
+        return 1.0;
+    }
+
+    let intersect = intersect(&counter(s1), &counter(s2));
+    let matches: usize = intersect.values().sum();
+    2.0 * (matches as f64) / (length as f64)
+}
+fn counter(s: &str) -> HashMap<char, usize> {
+    let mut count = HashMap::new();
+    for c in s.chars() {
+        *count.entry(c).or_insert(0) += 1;
+    }
+    count
+}
+
+fn intersect(map1: &HashMap<char, usize>, map2: &HashMap<char, usize>) -> HashMap<char, usize> {
+    let mut intersect = HashMap::new();
+    for (k, v) in map1 {
+        if let Some(v2) = map2.get(k) {
+            intersect.insert(*k, *v.min(v2));
+        }
+    }
+    intersect
+}
+
+pub struct SequenceMatcher;
+
+impl SimilarityMetric for SequenceMatcher {
+    fn compute_metric(&self, a: &str, b: &str) -> Similarity {
+        Similarity::Float(sequence_matcher(a, b))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quick_ratio() {
+        assert_eq!(sequence_matcher("test", "test"), 1.0);
+        assert_eq!(sequence_matcher("test", "tent"), 0.75);
+        assert_eq!(sequence_matcher("kitten", "sitting"), 0.6153846153846154);
+        assert_eq!(sequence_matcher("", ""), 1.0);
+        assert_eq!(sequence_matcher("test", ""), 0.0);
+        assert_eq!(sequence_matcher("", "test"), 0.0);
+    }
+}

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -14,23 +14,10 @@ macro_rules! assert_delta {
     };
 }
 
-#[cfg(feature = "damerau_levenshtein")]
 pub mod damerau_levenshtein;
-
-#[cfg(feature = "gestalt")]
 pub mod gestalt;
-
-#[cfg(feature = "hamming")]
 pub mod hamming;
-
-#[cfg(feature = "jaro")]
 pub mod jaro;
-
-#[cfg(feature = "levenshtein")]
 pub mod levenshtein;
-
-#[cfg(feature = "optimal_string_alignment")]
 pub mod optimal_string_alignment;
-
-#[cfg(feature = "sorensen_dice")]
 pub mod sorensen_dice;

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -14,9 +14,23 @@ macro_rules! assert_delta {
     };
 }
 
+#[cfg(feature = "damerau_levenshtein")]
 pub mod damerau_levenshtein;
+
+#[cfg(feature = "gestalt")]
+pub mod gestalt;
+
+#[cfg(feature = "hamming")]
 pub mod hamming;
+
+#[cfg(feature = "jaro")]
 pub mod jaro;
+
+#[cfg(feature = "levenshtein")]
 pub mod levenshtein;
+
+#[cfg(feature = "optimal_string_alignment")]
 pub mod optimal_string_alignment;
+
+#[cfg(feature = "sorensen_dice")]
 pub mod sorensen_dice;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub use algorithms::damerau_levenshtein::{
     damerau_levenshtein, generic_damerau_levenshtein, normalized_damerau_levenshtein,
     DamerauLevenshtein, NormalizedDamerauLevenshtein,
 };
+pub use algorithms::gestalt::sequence_matcher;
+pub use algorithms::gestalt::SequenceMatcher;
 pub use algorithms::hamming::hamming;
 pub use algorithms::jaro::{jaro, jaro_winkler};
 pub use algorithms::levenshtein::{


### PR DESCRIPTION
The python difflib uses a sequence macher method, based on the Gestalt (or Ratcliff/Obershelp) algorithm. Here, we add the algorithm to our list.