### PR TITLE
BUG: Fix feature dependent uses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,10 @@ rust-version = "1.70.0"
 
 [features]
 default = [
-  "damerau_levenshtein", "gestalt", "hamming", "jaro",
+  "damerau_levenshtein", "hamming", "jaro",
   "levenshtein", "optimal_string_alignment", "sorensen_dice"
 ]
 damerau_levenshtein = []
-gestalt = []
 hamming = []
 jaro = []
 levenshtein = []

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ footprint of your application and optimize performance.
 
 The crate includes the following features:
 
-- `damerau_levenshtein`
-- `gestalt`
-- `hamming`
-- `jaro`
-- `levenshtein`
-- `optimal_string_alignment`
-- `sorensen_dice`
+- damerau_levenshtein
+- gestalt
+- hamming
+- jaro
+- levenshtein
+- optimal_string_alignment
+- sorensen_dice
 
 By default, all features are included when you add `fuzzt` as a dependency.
 However, you can choose to include only specific features by listing them under

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -22,9 +22,7 @@ pub use damerau_levenshtein::{
     DamerauLevenshtein, NormalizedDamerauLevenshtein,
 };
 
-#[cfg(feature = "gestalt")]
 pub mod gestalt;
-#[cfg(feature = "gestalt")]
 pub use gestalt::{sequence_matcher, SequenceMatcher};
 
 #[cfg(feature = "hamming")]

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -16,30 +16,42 @@ macro_rules! assert_delta {
 
 #[cfg(feature = "damerau_levenshtein")]
 pub mod damerau_levenshtein;
+#[cfg(feature = "damerau_levenshtein")]
 pub use damerau_levenshtein::{
     damerau_levenshtein, generic_damerau_levenshtein, normalized_damerau_levenshtein,
     DamerauLevenshtein, NormalizedDamerauLevenshtein,
 };
+
 #[cfg(feature = "gestalt")]
 pub mod gestalt;
+#[cfg(feature = "gestalt")]
 pub use gestalt::{sequence_matcher, SequenceMatcher};
+
 #[cfg(feature = "hamming")]
 pub mod hamming;
+#[cfg(feature = "hamming")]
 pub use hamming::{hamming, Hamming};
+
 #[cfg(feature = "jaro")]
 pub mod jaro;
+#[cfg(feature = "jaro")]
 pub use jaro::{jaro, jaro_winkler, Jaro, JaroWinkler};
+
 #[cfg(feature = "levenshtein")]
 pub mod levenshtein;
+#[cfg(feature = "levenshtein")]
 pub use levenshtein::{
     generic_levenshtein, levenshtein, normalized_levenshtein, Levenshtein, NormalizedLevenshtein,
 };
 
 #[cfg(feature = "optimal_string_alignment")]
 pub mod optimal_string_alignment;
+#[cfg(feature = "optimal_string_alignment")]
 pub use optimal_string_alignment::{osa_distance, OSADistance};
+
 #[cfg(feature = "sorensen_dice")]
 pub mod sorensen_dice;
+#[cfg(feature = "sorensen_dice")]
 pub use sorensen_dice::{sorensen_dice, SorensenDice};
 
 pub enum Similarity {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,5 +1,5 @@
 use crate::{
-    algorithms::{NormalizedLevenshtein, Similarity, SimilarityMetric},
+    algorithms::{SequenceMatcher, Similarity, SimilarityMetric},
     processors::{NullStringProcessor, StringProcessor},
 };
 use std::cmp::Reverse;
@@ -48,7 +48,7 @@ pub fn get_top_n<'a>(
     let cutoff = cutoff.unwrap_or(0.7);
     let scorer = match scorer {
         Some(scorer_trait) => scorer_trait,
-        None => &NormalizedLevenshtein,
+        None => &SequenceMatcher,
     };
     let processor = match processor {
         Some(some_processor) => some_processor,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -12,16 +12,19 @@ use std::collections::BinaryHeap;
 /// # Arguments
 ///
 /// * `query` - A string to match against.
-/// * `choices` - A list of choices, suitable for use with extract().
-/// * `cutoff` - A score threshold. No matches with a score less than this number will be returned.
+/// * `choices` - A list of choices to compare against the query.
+/// * `cutoff` - A score threshold. No matches with a score less than this number will be returned. Defaults to 0.7.
 /// * `n` - Optional maximum for the number of elements returned. Defaults to 3.
 /// * `processor` - Optional function for transforming choices before matching. If not provided, `NullStringProcessor` is used.
-/// * `scorer` - Optional scoring function for extract(). If not provided, `Levenshtein` is used.
+/// * `scorer` - Optional scoring function for extract(). If not provided, `SequenceMatcher` is used.
 ///
 /// # Returns
 ///
 /// * A vector of the top 'n' matches from the given choices.
-///```
+///
+/// # Example
+///
+/// ```
 /// extern crate fuzzt;
 /// use fuzzt::{algorithms::NormalizedLevenshtein, get_top_n, processors::NullStringProcessor};
 ///
@@ -34,7 +37,7 @@ use std::collections::BinaryHeap;
 ///     Some(&NormalizedLevenshtein),
 /// );
 /// assert_eq!(matches, ["apples", "applet", "apply"]);
-///```
+/// ```
 pub fn get_top_n<'a>(
     query: &str,
     choices: &[&'a str],


### PR DESCRIPTION
When the algorithms were exposed it the root using conditional features, an error was raised since there was no default for the definition of  `get_top_n`. This was solved by removing one feature (for the SequenceMatcher) and making it always available (no feature dependent).